### PR TITLE
Fix Build error for wasm project 

### DIFF
--- a/Uno.MSAL.Graph.Demo.sln
+++ b/Uno.MSAL.Graph.Demo.sln
@@ -11,7 +11,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.MSAL.Graph.Demo.iOS", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.MSAL.Graph.Demo.UWP", "Uno.MSAL.Graph.Demo\Uno.MSAL.Graph.Demo.UWP\Uno.MSAL.Graph.Demo.UWP.csproj", "{8AA60300-B2F3-4D53-B08D-7BF12625CCD7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.MSAL.Graph.Demo.Wasm", "Uno.MSAL.Graph.Demo\Uno.MSAL.Graph.Demo.Wasm\Uno.MSAL.Graph.Demo.Wasm.csproj", "{3A61F01F-3413-4659-A63F-1F372CF908BA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.MSAL.Graph.Demo.Wasm", "Uno.MSAL.Graph.Demo\Uno.MSAL.Graph.Demo.Wasm\Uno.MSAL.Graph.Demo.Wasm.csproj", "{3A61F01F-3413-4659-A63F-1F372CF908BA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.MSAL.Graph.Demo.macOS", "Uno.MSAL.Graph.Demo\Uno.MSAL.Graph.Demo.macOS\Uno.MSAL.Graph.Demo.macOS.csproj", "{65689FFC-81CC-43E1-AF60-9942340A3427}"
 EndProject

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.Droid/Uno.MSAL.Graph.Demo.Droid.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.Droid/Uno.MSAL.Graph.Demo.Droid.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -64,9 +68,9 @@
     <PackageReference Include="Microsoft.Graph">
       <Version>3.7.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="33.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.471" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.478" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.Droid/Uno.MSAL.Graph.Demo.Droid.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.Droid/Uno.MSAL.Graph.Demo.Droid.csproj
@@ -69,8 +69,8 @@
       <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="3.1.0-dev.739" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.478" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.1.0-dev.739" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.UWP/Uno.MSAL.Graph.Demo.UWP.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.UWP/Uno.MSAL.Graph.Demo.UWP.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Uno.Core" Version="2.0.0" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.471" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
   </ItemGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.UWP/Uno.MSAL.Graph.Demo.UWP.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.UWP/Uno.MSAL.Graph.Demo.UWP.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Uno.Core" Version="2.0.0" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.1.0-dev.739" />
   </ItemGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.Wasm/Uno.MSAL.Graph.Demo.Wasm.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.Wasm/Uno.MSAL.Graph.Demo.Wasm.csproj
@@ -39,11 +39,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="3.7.0" />
-    <PackageReference Include="Uno.UI" Version="3.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.471" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.3.0-dev.42" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.3.0-dev.42" />
+    <PackageReference Include="Uno.UI" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.1.0-dev.739" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.WebAssembly" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.5.0-dev.57" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.5.0-dev.57" />
   </ItemGroup>
   <Import Project="..\Uno.MSAL.Graph.Demo.Shared\Uno.MSAL.Graph.Demo.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.MSAL.Graph.Demo.Shared\Uno.MSAL.Graph.Demo.Shared.projitems')" />
 </Project>

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.iOS/Uno.MSAL.Graph.Demo.iOS.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.iOS/Uno.MSAL.Graph.Demo.iOS.csproj
@@ -122,9 +122,9 @@
     <PackageReference Include="Microsoft.Graph">
       <Version>3.7.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="3.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.471" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.478" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.iOS/Uno.MSAL.Graph.Demo.iOS.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.iOS/Uno.MSAL.Graph.Demo.iOS.csproj
@@ -123,8 +123,8 @@
       <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="3.1.0-dev.739" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.478" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.1.0-dev.739" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.macOS/Uno.MSAL.Graph.Demo.macOS.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.macOS/Uno.MSAL.Graph.Demo.macOS.csproj
@@ -73,8 +73,8 @@
       <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="3.1.0-dev.739" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.478" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.1.0-dev.739" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.macOS/Uno.MSAL.Graph.Demo.macOS.csproj
+++ b/Uno.MSAL.Graph.Demo/Uno.MSAL.Graph.Demo.macOS/Uno.MSAL.Graph.Demo.macOS.csproj
@@ -72,9 +72,9 @@
     <PackageReference Include="Microsoft.Graph">
       <Version>3.7.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="3.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.471" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.471" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="3.1.0-dev.739" />
+    <PackageReference Include="Uno.UI.MSAL" Version="3.0.0-dev.478" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.478" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>


### PR DESCRIPTION
1. Fixed Build error for wasm project due to error(_Unable to find package Uno.UI.Wasm. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages, mynuget, nuget.org	Uno.MSAL.Graph.Demo.Wasm_)
2. Fixed Bug #1(Invalid PackageReference Uno.UI 33.0.0-dev.471 from Android project)
3. Upgrade the latest version of Uno Packages  

